### PR TITLE
Build Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,11 @@
+---
+defaults: &defaults
+  working_directory: /go/src/github.com/timberio/agent
+
 version: 2
 jobs:
-  build:
-    working_directory: /go/src/github.com/timberio/agent
+  test:
+    <<: *defaults
     docker:
       - image: circleci/golang:1.8
     environment:
@@ -23,3 +27,74 @@ jobs:
             make test | tee ${TEST_RESULTS}/go-test.out
       - store_test_results:
           path: /tmp/test-results
+  build_amd64_darwin:
+    <<: *defaults
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run:
+          name: Build for Darwin (amd64/x86_64)
+          command: |
+            make amd64-darwin-tarball
+      - persist_to_workspace:
+          root: build
+          paths:
+            - amd64-darwin
+  build_amd64_linux:
+    <<: *defaults
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run:
+          name: Build for Linux (amd64/x86_64)
+          command: |
+            make amd64-linux-tarball
+      - persist_to_workspace:
+          root: build
+          paths:
+            - amd64-linux
+  build_and_publish_docker_image:
+    <<: *defaults
+    docker:
+      - image: docker:17.03.0-ce
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /go/src/github.com/timberio/agent/build/amd64-linux
+      - setup_remote_docker
+      - run:
+          name: Build Docker Image
+          command: |
+            make docker-image
+      - run:
+          name: Publish Docker Image
+          command: |
+            VERSION=$(cat VERSION)
+            docker login -u $DOCKER_USER -p $DOCKER_PASSWORD
+            docker push timberio/agent:$(VERSION)
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - test
+      - build_darwin_amd64:
+          filters:
+            branches:
+              only: /refs\/tags\/v.*/
+          requires:
+            - test
+      - build_linux_amd64:
+          filters:
+            branches:
+              only: /refs\/tags\/v.*/
+          requires:
+            - test
+      - build_and_publish_docker_image:
+          filters:
+            branches:
+              only: /refs\/tags\/v.*/
+          requires:
+            - build_linux_amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine:3.6
+
+RUN mkdir -p /opt
+WORKDIR /opt
+COPY ./build/amd64-linux/ /opt
+
+ENTRYPOINT ["/opt/timber-agent/bin/timber-agent"]

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ amd64-linux-tarball: destination := $(distdir)/$(target)
 amd64-linux-tarball: amd64-linux
 	tar cjf $(distdir)/$(exec)-$(target)-$(version).tar.bz2 -C $(destination) $(exec)/
 
+docker-image: amd64-linux
+	@docker build -t timberio/agent:$(version) .
+
 test:
 	@go test -v
 


### PR DESCRIPTION
As part of our effort to support Kubernetes, we need to deploy the agent as a Docker image which can then be retrieved later as part of a container. It can also be used by any other system that is dependent upon Docker.

The image is built on a Linux Alpine base in order to produce an extremely small image.

CircleCI is set up to only build and deploy new versions of the image when a new version is published (by pushing a new tag starting with `v`).

Closes #22