### PR TITLE
Adding ability to discard logs on fatal instead of killing the agent.

### DIFF
--- a/config.go
+++ b/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	Hostname                   string
 	CollectEC2MetadataDisabled bool              `toml:"disable_ec2_metadata"`
 	KubernetesConfig           *KubernetesConfig `toml:"kubernetes"`
+	DiscardLogsOnFatal         bool              `toml:"discard_logs_on_fatal"`
 }
 
 type KubernetesConfig struct {

--- a/config_test.go
+++ b/config_test.go
@@ -112,6 +112,24 @@ path = "/var/log/log.log"
 	}
 }
 
+func TestNewConfigDiscardLogsOnFatal(t *testing.T) {
+	configString := `
+discard_logs_on_fatal = true
+`
+
+	configFile := strings.NewReader(configString)
+	config := NewConfig()
+	err := config.UpdateFromReader(configFile)
+	if err != nil {
+		panic(err)
+	}
+	actualValue := config.DiscardLogsOnFatal
+
+	if actualValue != true {
+		t.Errorf("Expected DiscardLogsOnFatal to be true but got non true value")
+	}
+}
+
 func TestNewConfigMultipleFiles(t *testing.T) {
 	configString := `
 default_api_key = "default_api_key"

--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func runCaptureStdin(ctx *cli.Context) error {
 
 	// Start forwarding STDIN
 	quit := handleSignals()
-	err = ForwardStdin(config.Endpoint, config.DefaultApiKey, config.BatchPeriodSeconds, metadata, quit)
+	err = ForwardStdin(config.Endpoint, config.DefaultApiKey, config.BatchPeriodSeconds, metadata, quit, config.DiscardLogsOnFatal)
 	if err != nil {
 		logger.Error(err)
 	} else {
@@ -268,7 +268,7 @@ func runCaptureFiles(ctx *cli.Context) error {
 	for fileConfig := range fileConfigsChan {
 		logger.Infof("Received file %s, attempting to foward", fileConfig.Path)
 		go func(fileConfig *FileConfig) {
-			err := ForwardFile(fileConfig.Path, config.Endpoint, fileConfig.ApiKey, config.Poll, config.BatchPeriodSeconds, metadata, quit, nil)
+			err := ForwardFile(fileConfig.Path, config.Endpoint, fileConfig.ApiKey, config.Poll, config.BatchPeriodSeconds, metadata, quit, nil, config.DiscardLogsOnFatal)
 			if err != nil {
 				logger.Error(err)
 			} else {
@@ -403,7 +403,7 @@ func runCaptureKube(ctx *cli.Context) error {
 				return
 			}
 
-			err = ForwardFile(fileConfig.Path, config.Endpoint, fileConfig.ApiKey, config.Poll, config.BatchPeriodSeconds, currentMetadata, quit, stop)
+			err = ForwardFile(fileConfig.Path, config.Endpoint, fileConfig.ApiKey, config.Poll, config.BatchPeriodSeconds, currentMetadata, quit, stop, config.DiscardLogsOnFatal)
 			if err != nil {
 				logger.Error(err)
 			} else {


### PR DESCRIPTION
Adding a config value to the toml agent config file to let the user enable the discarding of logs when a fatal error occurs during the forwarding.

For example, when `logs.timber.io` is unresponsive or down and `discard_logs_on_fatal` is true, logs will be discarded instead of the agent exiting.

Possible solution to #154